### PR TITLE
Add lencap functionality to parseFhir

### DIFF
--- a/configurations/configuration_fhir_measure_output/config_cql.ini
+++ b/configurations/configuration_fhir_measure_output/config_cql.ini
@@ -15,5 +15,5 @@ measure_year = Measure.measureYear.Value.Year
 patient = Patient.id.value
 
 # Flattened key/value pair
-key = Anchor:key
-value = Anchor:JsonDump:value
+cql_key = Anchor:key
+cql_value = Anchor:JsonDump:value.LenCap:|8000|data truncated

--- a/parseFhir.py
+++ b/parseFhir.py
@@ -167,9 +167,43 @@ def getJsonValue(lnjsn, ln,filename = ""):
                 lnjsn = spl[3]
         elif x.startswith("Left:"):
             spl = x[5:].split("|")
-            if isinstance(lnjsn, dict) and spl[0] in lnjsn:
+            # Support two forms:
+            # 1) Left:key|N  -> takes left N chars of lnjsn[key]
+            # 2) Left:|N     -> takes left N chars of the current value (if it is a string or list)
+            if len(spl) >= 2 and spl[0] == "" and isinstance(lnjsn, (str, list)):
+                lnjsn = lnjsn[:int(spl[1])]
+            elif isinstance(lnjsn, dict) and spl[0] in lnjsn:
                 lnjsn = lnjsn[spl[0]]
                 lnjsn = lnjsn[:int(spl[1])]
+            else:
+                return None
+        elif x.startswith("LenCap:"):
+            spl = x[7:].split("|")
+            # Support two forms similar to Left:
+            # 1) LenCap:key|N|placeholder -> if len(value)>N return placeholder else return original value
+            # 2) LenCap:|N|placeholder    -> operates on current value
+            if len(spl) >= 3 and spl[0] == "":
+                target = lnjsn
+                try:
+                    n = int(spl[1])
+                except Exception:
+                    return None
+                placeholder = spl[2]
+                if isinstance(target, (str, list)):
+                    lnjsn = placeholder if len(target) > n else target
+                else:
+                    return None
+            elif len(spl) >= 3 and isinstance(lnjsn, dict) and spl[0] in lnjsn:
+                target = lnjsn[spl[0]]
+                try:
+                    n = int(spl[1])
+                except Exception:
+                    return None
+                placeholder = spl[2]
+                if isinstance(target, (str, list)):
+                    lnjsn = placeholder if len(target) > n else target
+                else:
+                    return None
             else:
                 return None
         elif x.startswith("LTrim:"):


### PR DESCRIPTION
This PR adds functionality to truncate values longer than N length and optionally replace them with a placeholder like "data truncated".  

Updates CQL config to cap values longer than 8000 chars to prevent data loading issues in the Tuva Project.