### PR TITLE
[Bug] Update license file path in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A simple library to parse FHIR JSON/NDJSON into CSV/Parquet or DataFrame"
 readme = "README.md"
 requires-python = ">=3.8"
-license = { file = "license" }
+license = { file = "license/license-2.0.txt" }
 authors = [
   { name = "FHIR Inferno Contributors" }
 ]


### PR DESCRIPTION
Repo has a license directory; packaging was using license as a file path, which caused [Errno 21] Is a directory during install. Updating the license entry to the actual file (e.g. license = { file = "license/license-2.0.txt" }) so the build uses a real file and the dependency installs successfully.